### PR TITLE
feat: standalone cli improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "tsc": "tsc -b",
     "lint": "run-s lint:*",
     "lint-check": "run-s lint-check:*",
-    "lint:isort": "pnpm lint-check:isort --fix",
-    "lint-check:isort": "./bin/cli.js $(git grep -l . '*.ts') $(git ls-files --others --exclude-standard '*.ts')",
+    "lint:isort": "./bin/cli.js --git --fix",
+    "lint-check:isort": "./bin/cli.js --git",
     "lint:prettier": "prettier --write --cache .",
     "lint-check:prettier": "prettier --check --cache .",
     "release": "pnpm publish --no-git-checks --access public"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "release": "pnpm publish --no-git-checks --access public"
   },
   "dependencies": {
+    "cac": "^6.7.14",
+    "consola": "^2.15.3",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/isort-ts",
-  "version": "1.0.0-pre.3",
+  "version": "1.0.0-pre.4",
   "type": "commonjs",
   "main": "./dist/index.js",
   "bin": "./bin/cli.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ specifiers:
   '@types/lodash': ^4.14.191
   '@types/node': ^18.14.1
   '@types/prettier': ^2.7.2
+  cac: ^6.7.14
+  consola: ^2.15.3
   lodash: ^4.17.21
   npm-run-all: ^4.1.5
   prettier: ^2.8.3
@@ -14,6 +16,8 @@ specifiers:
   vitest: ^0.28.5
 
 dependencies:
+  cac: 6.7.14
+  consola: 2.15.3
   lodash: 4.17.21
 
 devDependencies:
@@ -613,7 +617,6 @@ packages:
   /cac/6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
@@ -689,6 +692,10 @@ packages:
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
+
+  /consola/2.15.3:
+    resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
+    dev: false
 
   /cross-spawn/6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,8 +19,8 @@ async function runCommand(
   options: { fix: boolean; git: boolean; cache: boolean }
 ) {
   const results = {
-    ok: 0,
-    nochange: 0,
+    fixable: 0,
+    correct: 0,
     error: 0,
   };
 
@@ -33,10 +33,10 @@ async function runCommand(
           await fs.promises.writeFile(filePath, output);
         }
         consola.info(filePath);
-        results.ok++;
+        results.fixable++;
       } else {
         consola.success(filePath);
-        results.nochange++;
+        results.correct++;
       }
     } catch (e) {
       consola.error(filePath, e);
@@ -51,7 +51,7 @@ async function runCommand(
       process.exit(1);
     }
   } else {
-    if (results.ok || results.error) {
+    if (results.fixable || results.error) {
       process.exit(1);
     }
   }


### PR DESCRIPTION
- [x] setup cac for cli entrypoint
- [x] use consola for log format
- [x] `--git` mode for quick file collection
- [ ] `--cache`

## help message

```sh
$ ./bin/cli.js --help
isort-ts

Usage:
  $ isort-ts [...files]

Commands:
  [...files]  check import order

For more info, run any command with the `--help` flag:
  $ isort-ts --help

Options:
  --fix       apply sorting in-place 
  --cache     enable caching (TODO) 
  --git       collect files based on git (TODO) 
  -h, --help  Display this message 
```

## example run

```sh
$ ./bin/cli.js src/*.ts README.md
✔ src/cli.ts 90 ms                                                                       19:49:30
✔ src/index.ts 3 ms                                                                      19:49:30
✔ src/misc.ts 17 ms                                                                      19:49:30
✔ src/prettier-plugin.ts 5 ms                                                            19:49:30
✔ src/transformer.test.ts 10 ms                                                          19:49:30
ℹ src/transformer.ts 41 ms                                                               19:49:30
✔ tsup.config.ts 5 ms                                                                    19:49:30

 ERROR  README.md isort-ts parse error                                                   19:25:01

  at tsAnalyze (dist/cli.js:141:11)
  at tsTransformIsort (dist/cli.js:146:18)
  at runTransform (dist/cli.js:202:22)
  at async Promise.all (index 6)
  at async CAC.runCommand (dist/cli.js:218:3)
  at async main (dist/cli.js:232:5)
```