### PR TITLE
fix: fix git empty match error

### DIFF
--- a/.changeset/khaki-tables-tan.md
+++ b/.changeset/khaki-tables-tan.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/isort-ts": patch
+---
+
+fix cli error on git empty match

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -228,9 +228,9 @@ function hashString(input: string): string {
 const promisifyExec = promisify(exec);
 
 async function collectFilesByGit(): Promise<string[]> {
+  // fails when no-match but that's probably desired
   const COMMANDS = [
-    "git grep -l . '*.ts' '*.tsx'",
-    "git ls-files --others --exclude-standard '*.ts' '*.tsx'",
+    "git grep -l --untracked --exclude-standard . '*.ts' '*.tsx'",
   ];
   let files: string[] = [];
   for (const command of COMMANDS) {


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/isort-ts/issues/19

It turns out `git grep` supports untracked files too.