### PR TITLE
fix: fix default order for `"."`

### DIFF
--- a/.changeset/olive-candles-jump.md
+++ b/.changeset/olive-candles-jump.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/isort-ts": patch
+---
+
+fix: fix default ordering for "."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/isort-ts",
-  "version": "1.0.2-pre.0",
+  "version": "1.0.2-pre.1",
   "type": "commonjs",
   "main": "./dist/index.js",
   "bin": "./bin/cli.js",

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -30,7 +30,7 @@ export const DEFAULT_OPTIONS: IsortOptions = {
     NODE_BUILTIN_RE, // node:process, process
     /^.*:/,          // virtual:uno.css
     /^[^./]/,        // any-external
-    /./,         // ./any-local
+    /./,             // ./any-local
   ],
   isortIgnoreDeclarationSort: false,
   isortIgnoreMemberSort: false,

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -30,7 +30,7 @@ export const DEFAULT_OPTIONS: IsortOptions = {
     NODE_BUILTIN_RE, // node:process, process
     /^.*:/,          // virtual:uno.css
     /^[^./]/,        // any-external
-    /[^./]/,         // ./any-local
+    /./,         // ./any-local
   ],
   isortIgnoreDeclarationSort: false,
   isortIgnoreMemberSort: false,

--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -226,6 +226,9 @@ import z from "external";
 import { D, C, b, a } from "a";
 import "side-effect";
 import process1 from "process";
+import i1 from ".";
+import i2 from "./";
+import i3 from "./index";
 import process2 from "node:process";
 `;
     expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
@@ -234,6 +237,9 @@ import process2 from "node:process";
       import process1 from \\"process\\";
       import { C, D, a, b } from \\"a\\";
       import z from \\"external\\";
+      import i1 from \\".\\";
+      import i2 from \\"./\\";
+      import i3 from \\"./index\\";
       import y from \\"./local-a\\";
       import x from \\"./local-z\\";
       "


### PR DESCRIPTION
I was wondering where this odd ordering is coming from:

```ts
import { PRACTICE_ACTION_TYPE_TO_COLOR, QueueTypeIcon } from ".";
import { Transition } from "@headlessui/react";
```

https://github.com/hi-ogawa/ytsub-v3/blob/02ecc72440ce6bbd35f05bace3fb45664b9e070b/app/routes/decks/%24id/history.tsx#L1-L2

This PR should fix this.